### PR TITLE
Allow task titles to be edited without flag 

### DIFF
--- a/src/main/java/seedu/todo/logic/commands/BaseCommand.java
+++ b/src/main/java/seedu/todo/logic/commands/BaseCommand.java
@@ -83,7 +83,7 @@ public abstract class BaseCommand {
         // Does no additional validation by default 
     }
     
-    private void setPositionalArgument(String argument) {
+    protected void setPositionalArgument(String argument) {
         for (Parameter p : getArguments()) {
             if (p.isPositional()) {
                 try {
@@ -95,7 +95,7 @@ public abstract class BaseCommand {
         }
     }
     
-    private void setNameArgument(String flag, String argument) {
+    protected void setNameArgument(String flag, String argument) {
         for (Parameter p : getArguments()) {
             if (flag.equals(p.getFlag())) {
                 try {

--- a/src/main/java/seedu/todo/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/todo/logic/commands/EditCommand.java
@@ -1,19 +1,21 @@
 package seedu.todo.logic.commands;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import seedu.todo.commons.exceptions.IllegalValueException;
 import seedu.todo.commons.exceptions.ValidationException;
 import seedu.todo.logic.arguments.*;
 import seedu.todo.model.task.ImmutableTask;
 
+import java.util.Iterator;
 import java.util.List;
 
 public class EditCommand extends BaseCommand {
     private static final String VERB = "edited";
     
+    // These parameters will be sorted out manually
     private Argument<Integer> index = new IntArgument("index").required();
-    
-    private Argument<String> title = new StringArgument("title")
-            .flag("t");
+    private Argument<String> title = new StringArgument("title");
     
     private Argument<String> description = new StringArgument("description")
             .flag("m");
@@ -42,6 +44,25 @@ public class EditCommand extends BaseCommand {
         return ImmutableList.of(new CommandSummary("Edit task", getCommandName(), 
             getArgumentSummary()));
 
+    }
+
+    @Override
+    protected void setPositionalArgument(String argument) {
+        String[] tokens = argument.trim().split("\\s+", 2);
+
+        try {
+            index.setValue(tokens[0].trim());
+        } catch (IllegalValueException e) {
+            errors.put(index.getName(), e.getMessage());
+        }
+        
+        if (tokens.length > 1) {
+            try {
+                title.setValue(tokens[1].trim());
+            } catch (IllegalValueException e) {
+                errors.put(index.getName(), e.getMessage());
+            }
+        }
     }
 
     @Override

--- a/src/main/java/seedu/todo/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/todo/logic/commands/EditCommand.java
@@ -1,19 +1,17 @@
 package seedu.todo.logic.commands;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import seedu.todo.commons.exceptions.IllegalValueException;
 import seedu.todo.commons.exceptions.ValidationException;
 import seedu.todo.logic.arguments.*;
 import seedu.todo.model.task.ImmutableTask;
 
-import java.util.Iterator;
 import java.util.List;
 
 public class EditCommand extends BaseCommand {
     private static final String VERB = "edited";
     
-    // These parameters will be sorted out manually
+    // These parameters will be sorted out manually by overriding setPositionalArgument
     private Argument<Integer> index = new IntArgument("index").required();
     private Argument<String> title = new StringArgument("title");
     
@@ -49,18 +47,13 @@ public class EditCommand extends BaseCommand {
     @Override
     protected void setPositionalArgument(String argument) {
         String[] tokens = argument.trim().split("\\s+", 2);
-
-        try {
-            index.setValue(tokens[0].trim());
-        } catch (IllegalValueException e) {
-            errors.put(index.getName(), e.getMessage());
-        }
+        Parameter[] positionals = new Parameter[]{ index, title };
         
-        if (tokens.length > 1) {
+        for (int i = 0; i < tokens.length; i++) {
             try {
-                title.setValue(tokens[1].trim());
+                positionals[i].setValue(tokens[i].trim());
             } catch (IllegalValueException e) {
-                errors.put(index.getName(), e.getMessage());
+                errors.put(positionals[i].getName(), e.getMessage());
             }
         }
     }

--- a/src/test/java/seedu/todo/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/todo/logic/commands/EditCommandTest.java
@@ -45,8 +45,7 @@ public class EditCommandTest extends CommandTest {
     
     @Test
     public void testEditTitle() throws Exception {
-        setParameter("1");
-        setParameter("t", "New Title");
+        setParameter("1 New Title");
         execute(true);
         
         ImmutableTask task = getTaskAt(1);
@@ -145,8 +144,7 @@ public class EditCommandTest extends CommandTest {
 
     @Test
     public void testEditMoreThanOneParameter() throws Exception {
-        setParameter("t", "New Title");
-        setParameter("1");
+        setParameter("1 New Title");
         setParameter("m", "New description");
         setParameter("l", "Singapura");
         execute(true);


### PR DESCRIPTION
That is, instead of `edit 2 /t New title`, `edit 2 New title` will now work. Fixes #112 
