### PR TITLE
Fix model delete bug

### DIFF
--- a/src/main/java/seedu/todo/model/TodoModel.java
+++ b/src/main/java/seedu/todo/model/TodoModel.java
@@ -146,9 +146,10 @@ public class TodoModel implements Model {
     @Override
     public ImmutableTask delete(int index) throws ValidationException {
         saveUndoState();
-        ImmutableTask taskToDelete = getObservableList().get(getTaskIndex(index));
+        int taskIndex = getTaskIndex(index);
+        ImmutableTask taskToDelete = tasks.get(taskIndex);
         uniqueTagCollection.notifyTaskDeleted(taskToDelete);
-        return todoList.delete(getTaskIndex(index));
+        return todoList.delete(taskIndex);
     }
 
     @Override

--- a/src/test/java/seedu/todo/model/TodoModelTest.java
+++ b/src/test/java/seedu/todo/model/TodoModelTest.java
@@ -92,6 +92,24 @@ public class TodoModelTest {
         model.add("Foo Bar Test");
         model.delete(2);
     }
+    
+    @Test
+    public void testFilteredDelete() throws Exception {
+        model.add("First");
+        model.add("Second");
+        model.find(t -> t.getTitle().equals("Second"));
+        model.delete(1);
+        assertEquals("First", getTask(0).getTitle());
+    }
+
+    @Test
+    public void testFilteredUpdate() throws Exception {
+        model.add("First");
+        model.add("Second");
+        model.find(t -> t.getTitle().equals("Second"));
+        model.update(1, t -> t.setTitle("New Title"));
+        assertEquals("New Title", getTask(1).getTitle());
+    }
 
     @Test
     public void testSorting() throws Exception {


### PR DESCRIPTION
Recent changes to the TodoModel introduced a bug into the `delete` method. This fixes it and adds some tests to make sure it doesn't happen again. 
