### PR TITLE
Warm up PrettyTime NLP 

### DIFF
--- a/src/main/java/seedu/todo/logic/arguments/DateRangeArgument.java
+++ b/src/main/java/seedu/todo/logic/arguments/DateRangeArgument.java
@@ -1,9 +1,9 @@
 package seedu.todo.logic.arguments;
 
-import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 import seedu.todo.commons.exceptions.IllegalValueException;
 import seedu.todo.commons.util.StringUtil;
 import seedu.todo.commons.util.TimeUtil;
+import seedu.todo.logic.parser.TodoParser;
 
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 
 //@@author A0135817B
 public class DateRangeArgument extends Argument<DateRange> {
-    private static final PrettyTimeParser parser = new PrettyTimeParser();
     private static final TimeUtil timeUtil = new TimeUtil();
     
     // TODO: Review all error messages to check for user friendliness 
@@ -38,7 +37,7 @@ public class DateRangeArgument extends Argument<DateRange> {
         }
         
         input = TimeUtil.toAmericanDateFormat(input);
-        List<Date> dateGroups = parser.parse(input);
+        List<Date> dateGroups = TodoParser.dateTimeParser.parse(input);
         
         List<LocalDateTime> dates = dateGroups.stream()
             .map(TimeUtil::asLocalDateTime)

--- a/src/main/java/seedu/todo/logic/parser/TodoParser.java
+++ b/src/main/java/seedu/todo/logic/parser/TodoParser.java
@@ -2,6 +2,8 @@ package seedu.todo.logic.parser;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
+import javafx.application.Platform;
+import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 
 import java.util.*;
 import java.util.Map.Entry;
@@ -17,7 +19,17 @@ import java.util.Map.Entry;
  * optionally many named arguments. 
  */
 public class TodoParser implements Parser {
-    public static String FLAG_TOKEN = "/";
+    // Best practice would dictate this property be inside DateRangeArgument instead
+    // but PrettyTimeParser takes several seconds to warm up, so instead we do it in the 
+    // TodoLogic constructor, which is initialized on app startup. 
+    public static final PrettyTimeParser dateTimeParser = new PrettyTimeParser();
+    
+    public static final String FLAG_TOKEN = "/";
+    
+    public TodoParser() {
+        // Try to warm up the parser a little on a background thread
+        new Thread(() -> dateTimeParser.parse("next Wednesday 2pm to 6pm")).start();
+    }
 
     private List<String> tokenize(String input) {
         input = input.trim();

--- a/src/main/java/seedu/todo/logic/parser/TodoParser.java
+++ b/src/main/java/seedu/todo/logic/parser/TodoParser.java
@@ -2,7 +2,6 @@ package seedu.todo.logic.parser;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
-import javafx.application.Platform;
 import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 
 import java.util.*;


### PR DESCRIPTION
This forces the NLP to warm up by running the parse method during `TodoLogic`'s constructor. Several alternatives were considered, including moving the parser to a singleton (works, but would involve adding a lot of code for this one thing) and using an app start event (doesn't work well with static methods), but I think this is the better solution. 

This solves one of the more noticeable performance issues in #73 
